### PR TITLE
Admin API: fix sequence number ordering for option parameters

### DIFF
--- a/web/admin/API.php
+++ b/web/admin/API.php
@@ -82,6 +82,9 @@ switch($sanitised_action) {
         $fed = new Federation($federation);
         $idp = new IdP($fed->newIdP("PENDING", "API", valid_string_db($_POST['NEWINST_PRIMARYADMIN'])));
         
+        // ensure seq. number asc. order for options (S1, S2...)
+        uksort($_POST['option'],"cmpSequenceNumber");
+
         $instWideOptions = $_POST;
         foreach ($instWideOptions['option'] as $optindex => $optname) {
             if (!preg_match("/^general:/",$optname) && !preg_match("/^support:/",$optname) && !preg_match("/^eap:/",$optname)) {

--- a/web/admin/inc/option_parse.inc.php
+++ b/web/admin/inc/option_parse.inc.php
@@ -13,6 +13,16 @@ require_once("Options.php");
 
 require_once("input_validation.inc.php");
 
+function cmpSequenceNumber($a, $b) {
+  $pat = "/^S([0-9]+)(-.*)?$/";
+  $rep = "$1";
+  $a_ = (int)preg_replace($pat, $rep, $a);
+  $b_ = (int)preg_replace($pat, $rep, $b);
+  return ($a != $a_ && $b != $b_) ?
+    $a_ - $b_ :
+    strcmp($a, $b);
+}
+
 function postProcessValidAttributes($options, &$good, &$bad) {
     foreach ($options as $index => $iterateOption) {
         foreach ($iterateOption as $name => $value) {

--- a/web/admin/inc/option_parse.inc.php
+++ b/web/admin/inc/option_parse.inc.php
@@ -13,14 +13,14 @@ require_once("Options.php");
 
 require_once("input_validation.inc.php");
 
-function cmpSequenceNumber($a, $b) {
+function cmpSequenceNumber($left, $right) {
   $pat = "/^S([0-9]+)(-.*)?$/";
   $rep = "$1";
-  $a_ = (int)preg_replace($pat, $rep, $a);
-  $b_ = (int)preg_replace($pat, $rep, $b);
-  return ($a != $a_ && $b != $b_) ?
-    $a_ - $b_ :
-    strcmp($a, $b);
+  $leftNum = (int)preg_replace($pat, $rep, $left);
+  $rightNum = (int)preg_replace($pat, $rep, $right);
+  return ($left != $leftNum && $right != $rightNum) ?
+    $leftNum - $rightNum :
+    strcmp($left, $right);
 }
 
 function postProcessValidAttributes($options, &$good, &$bad) {


### PR DESCRIPTION
Quoting from the [wiki](https://wiki.geant.org/display/H2eduroam/A+guide+to+eduroam+CAT+for+federation+administrators):

> The POST parameter option[Sx] specifies the name of the attribute to set; yes, that is a literal character "S" followed by an integer number of your choice (numbers do not need to be consecutive nor start at 1). All options can occur more than once.

>|Option Name|Explanation|
|---|---|
|profile-api:eaptype | integer value of a supported EAP type, as per the following table. Preference of EAP types is determined by the order induced by their option[Sx] sequence number.|

My understanding of the above is that if x < y, then option[Sx] < option[Sy] -- or perhaps the same in descending order.

However that is not the case. PHP produces a hierarchy of associative arrays from such parameters in $_POST, but nothing maintains the order induced by sequence numbers. If one sends options S20, S2, S200 (all profile-api:eaptype) with values 1, 2, 3 respectively, the resulting preference is not 2, 1, 3, nor 3, 1, 2, but rather it is the order these options were posted in.

One can work around this by posting the options in the right order, however if I am reading the wiki excerpt above correctly, I believe CAT should do this, hence this patch.