### PR TITLE
Use altsubject_match if possible

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -502,6 +502,9 @@ class InstallerData:
 
 class WpaConf:
     def prepare_network_block(self,ssid,user_data):
+        altsubj_match = "altsubject_match=\"%s\"" % ";".join(Config.servers)
+        domain_suffix_match = "domain_suffix_match=\"%s\"" % Config.server_match
+
         out = """network={
         ssid=""" + ssid + """
         key_mgmt=WPA-EAP 
@@ -510,7 +513,7 @@ class WpaConf:
         eap=""" + Config.eap_outer + """
         ca_cert=\"""" + os.environ.get('HOME') + """/.cat_installer/ca.pem\"
         identity=\"""" + user_data.USERNAME + """\"
-        domain_suffix_match=\"""" + Config.server_match + """\"
+        """ + (altsubj_match if Config.servers else domain_suffix_match) + """
         phase2=\"auth=""" + Config.eap_inner + """\"
         password=\"""" + user_data.PASSWORD + """\"
         anonymous_identity=\"""" + Config.anonymous_identity + """\"


### PR DESCRIPTION
Fixes #131 

Tested with the following settings of Config.servers:
* `[]`
* `['DNS:radius']`
* `['DNS:radius1', 'DNS:radius2']`

Tested using Python 2.7 and Python 3.6.