### PR TITLE
Add interactive mode

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+
+import argparse
 import subprocess 
 import sys
 


### PR DESCRIPTION
We use this mode to test interactive the linux installer with docker and a lot of linux distros. It would be nice if you could add this so that our code is synchronous with our code.

With this pull request, you have the parameter ``-d/--debug``, ``-y/--yes``, ``-u/--username`` and ``-p/--password``.

It would be nice if you could merge the pull request instead of copy and paste my code by the way. There wouldn't be a difference.