### PR TITLE
Add requirements

### DIFF
--- a/devices/linux/Files/requirements.txt
+++ b/devices/linux/Files/requirements.txt
@@ -1,0 +1,2 @@
+distro
+keyring

--- a/devices/linux/Files/requirements_dev.txt
+++ b/devices/linux/Files/requirements_dev.txt
@@ -1,0 +1,7 @@
+distro
+keyring
+
+flake8
+pep8
+isort
+pylint3


### PR DESCRIPTION
Only with ``requirements_dev.txt`` works the ``Makefile``. The ``requirements.txt`` is for people who want only use it. But its only for information and not for the normal eduroam user.

I added also the module ``keyring``. I will program soon that it will work with the keyring.