### PR TITLE
Add windows arm support for GEANTLink

### DIFF
--- a/devices/ms/Files/common.inc
+++ b/devices/ms/Files/common.inc
@@ -335,16 +335,16 @@ Function .onInit
       StrCpy $Platform "x86"
       StrCpy $Netsh "netsh"
       StrCpy $Msiexec "msiexec"
-     ${Else}
+    ${Else}
        Abort "Unsupported CPU architecture!"
     ${EndIf}
   !else
     ${If} ${RunningX64}
-      StrCpy $Platform "64"
+      StrCpy $Platform "x64"
       StrCpy $Netsh "$WINDIR\sysnative\netsh"
       StrCpy $Msiexec "$WINDIR\sysnative\msiexec"
       ${Else}
-      StrCpy $Platform "32"
+      StrCpy $Platform "x86"
       StrCpy $Netsh "netsh"
       StrCpy $Msiexec "msiexec"
     ${EndIf}

--- a/devices/ms/Files/common.inc
+++ b/devices/ms/Files/common.inc
@@ -321,16 +321,34 @@ Function .onInit
   Push 0
   Pop $profile_fail
 
-
-  ${If} ${RunningX64}
-    StrCpy $Platform "64"
-    StrCpy $Netsh "$WINDIR\sysnative\netsh"
-    StrCpy $Msiexec "$WINDIR\sysnative\msiexec"
-    ${Else}
-    StrCpy $Platform "32"
-    StrCpy $Netsh "netsh"
-    StrCpy $Msiexec "msiexec"
-  ${EndIf}
+  # switch between nsis 3.03 and 3.04
+  !if "${NSIS_PACKEDVERSION}" > 0x3003000 ;
+    ${If} ${IsNativeAMD64}
+      StrCpy $Platform "x64"
+      StrCpy $Netsh "$WINDIR\sysnative\netsh"
+      StrCpy $Msiexec "$WINDIR\sysnative\msiexec"
+    ${ElseIf} ${IsNativeARM64}
+      StrCpy $Platform "ARM64"
+      StrCpy $Netsh "$WINDIR\sysnative\netsh"
+      StrCpy $Msiexec "$WINDIR\sysnative\msiexec"
+    ${ElseIf} ${IsNativeIA32}
+      StrCpy $Platform "x86"
+      StrCpy $Netsh "netsh"
+      StrCpy $Msiexec "msiexec"
+     ${Else}
+       Abort "Unsupported CPU architecture!"
+    ${EndIf}
+  !else
+    ${If} ${RunningX64}
+      StrCpy $Platform "64"
+      StrCpy $Netsh "$WINDIR\sysnative\netsh"
+      StrCpy $Msiexec "$WINDIR\sysnative\msiexec"
+      ${Else}
+      StrCpy $Platform "32"
+      StrCpy $Netsh "netsh"
+      StrCpy $Msiexec "msiexec"
+    ${EndIf}
+  !endif
   !insertmacro debug_cat 3 "Platfrom:$Platform"
 
   Call wVersionCheck

--- a/devices/ms/Files/geant_link.inc
+++ b/devices/ms/Files/geant_link.inc
@@ -83,17 +83,20 @@ Function InstallGEANTLink
   Pop $0
   !insertmacro debug_cat 4 "MsiUseFeature returned $0"
   StrCmp $0 0 Cont2
-  File "GEANTLink32.msi"
-  nsArray::Set Delete_files "GEANTLink32.msi"
-  File "GEANTLink64.msi"
-  nsArray::Set Delete_files "GEANTLink64.msi"
+  File "GEANTLink-x86.msi"
+  nsArray::Set Delete_files "GEANTLink-x86.msi"
+  File "GEANTLink-x64.msi"
+  nsArray::Set Delete_files "GEANTLink-x64.msi"
   DetailPrint "Install GEANTLink installer"
+  File "GEANTLink-x86.msi"
+  nsArray::Set Delete_files "GEANTLink-ARM64.msi"
+  File "GEANTLink-ARM64.msi"
   IfSilent +2
   MessageBox MB_OK  "<?php WindowsCommon::echo_nsi( _("An additional piece of software 'GEANTlink' needs to be installed. This installation requires Administrator rights; you will be prompted to give permission for that action."))?>"
   !insertmacro debug_cat 1 "Run GEANTLink installer"
-  !insertmacro debug_cat 3 'Execute: msiexec.exe /i "$OUTDIR\GEANTLink$Platform.msi" REBOOT=Supress'
+  !insertmacro debug_cat 3 'Execute: msiexec.exe /i "$OUTDIR\GEANTLink-$Platform.msi" REBOOT=Supress'
   ClearErrors
-  ExecWait '$Msiexec.exe /i "$TEMP\GEANTLink$Platform.msi" /qb REBOOT=Supress' $0
+  ExecWait '$Msiexec.exe /i "$TEMP\GEANTLink-$Platform.msi" /qb REBOOT=Supress' $0
   !insertmacro debug_cat 4 "GEANTLink returned $0"
   StrCmp $0 0 Cont2
   ${If} $0 == 3010

--- a/devices/ms/WindowsCommon.php
+++ b/devices/ms/WindowsCommon.php
@@ -69,8 +69,9 @@ abstract class WindowsCommon extends \core\DeviceConfig {
     }
 
     public function copyGeantLinkFiles() {
-        if (!($this->copyFile('GEANTLink/GEANTLink32.msi', 'GEANTLink32.msi') &&
-                $this->copyFile('GEANTLink/GEANTLink64.msi', 'GEANTLink64.msi') &&
+        if (!($this->copyFile('GEANTLink/GEANTLink-x86.msi', 'GEANTLink-x86.msi') &&
+                $this->copyFile('GEANTLink/GEANTLink-x64.msi', 'GEANTLink-x64.msi') &&
+                $this->copyFile('GEANTLink/GEANTLink-ARM64.msi', 'GEANTLink-ARM64.msi') &&
                 $this->copyFile('GEANTLink/CredWrite.exe', 'CredWrite.exe') &&
                 $this->copyFile('GEANTLink/MsiUseFeature.exe', 'MsiUseFeature.exe'))) {
             throw new Exception("Copying needed files (GEANTLink) failed for at least one file!");


### PR DESCRIPTION
Hello guys,

I had the idea that we could add arm support. So here are a pull request with few changes.

It works only with ``nsis3.04`` but is still compatible with  older ``nsis`` versions. I use the ``IsNative`` function from the new ``nsis 3.04`` version (see [Release Notes](https://nsis.sourceforge.io/Docs/AppendixF.html#v3.04)).
You have to update also the submodule from GEANTLink so that you could use latest ``GEANTLINK-ARM64.exe``.



