### PR TITLE
Use geantlink only if needed

### DIFF
--- a/devices/ms/Files/geant_link.inc
+++ b/devices/ms/Files/geant_link.inc
@@ -35,8 +35,16 @@ File "CredWrite.exe"
 nsArray::Set Delete_files "CredWrite.exe"
 File "MsiUseFeature.exe"
 nsArray::Set Delete_files "MsiUseFeature.exe"
-Call InstallGEANTLink
+
+!if "${NSIS_PACKEDVERSION}" > 0x3003000
+  ${If} ${AtMostWaaS} "Fall Creators Update"
+    Call InstallGEANTLink
+  ${EndIf}
+!else
+  Call InstallGEANTLink
+!endif
 SectionEnd
+
 ;TRANSLATION
 Section "<?php echo _("Installation of network profiles")?>" "<?php echo _("profiles")?>"
 SectionIn RO


### PR DESCRIPTION
Hello,

I read at the mailing list that we need only GEANTLink until windows 10 build 1803. So we don't have to install GEANTLink starting from 1803, do we?

I used for this the nsis 3.04 and the ``AtMostWaaS`` macro from ``WinVer.nsh``.

Additional question: which branch should I use? Still ``release_2_0``?