### PR TITLE
eap-config silently converts TTLS-MSCHAPv2 to TTLS-EAP-MSCHAPv2

### DIFF
--- a/devices/eap_config/DeviceXML.php
+++ b/devices/eap_config/DeviceXML.php
@@ -174,13 +174,7 @@ abstract class DeviceXML extends \core\DeviceConfig
     {
         $out = [];
         $out['EAP'] = 0;
-        // this is a hack - eduroamCAT does not handle NE_MSCHAP2 however
-        // treats the inner NE_MSCHAP2 correctly wheb set to the EAP type
         switch ($eap["INNER"]) {
-            case \core\common\EAP::NE_MSCHAP2:
-                $out['METHOD'] = \core\common\EAP::MSCHAP2;
-                $out['EAP'] = 1;
-                break;
             case \core\common\EAP::NE_SILVERBULLET:
                 $out['METHOD'] = \core\common\EAP::NONE;
                 break;


### PR DESCRIPTION
# Issue type

- Defect - Unexpected behaviour (obvious or has been verified by a project member).

# Defect/Feature description

## How to reproduce issue

When creating a profile with TTLS-MSCHAPv2, the eap-config instructs the client to configure TTLS-EAP-MSCHAPv2 instead. Other profiles (tested ChromeOS, Linux and Mobileconfig) do configure TTLS-MSCHAPv2 as requested.
 
## Detail of issue

When creating a profile with TTLS-PAP, the eap-config contains

	<InnerAuthenticationMethod>
	<NonEAPAuthMethod><Type>1</Type></NonEAPAuthMethod>
	</InnerAuthenticationMethod>

However, when creating a profile with TTLS-MSCHAPv2, the eap-config contains

	<InnerAuthenticationMethod>
	<EAPMethod><Type>26</Type></EAPMethod>
	</InnerAuthenticationMethod>

There appears to be a workaround in the eap-config code (with a comment stating "this is a hack"). I don't completely understand the code, but it appears that a Non-EAP authentication (negative number in CAT) is converted to the equivalent EAP number.

This seems unnecessary; according to the problem, there is some problem with eduroamCAT (this software?) when generating the Non-EAP version which is why the EAP-version is generated instead. But that's not the case; NE_MSCHAP2 is -3, in eap-config Non-EAP MSCHAPv2 is 3 (according to eap-metadata.xsd) and the code uses abs() on the inner method (so -3 becomes 3).

There may be another reason why this code was introduced. I tried searching in the Git history, but couldn't come up with a reason; the code was introduced only two months ago, in 80a561b, which is a rather large commit. It seems to replace the similar still available but unreachable from the API "xml" device, which does not have this workaround.

---

Since I'm just removing code here, that someone probably put there for a reason, I'm marking this PR as "draft" so that it cannot be merged yet.