### PR TITLE
Testing for empty dbus package caused by PyQT5

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -804,6 +804,11 @@ class CatNMConfigTool(object):
         """
         try:
             self.bus = dbus.SystemBus()
+        except AttributeError:
+            # since dbus existed but is empty we have an empty package
+            # this gets shipped by pyqt5
+            print("DBus not properly installed")
+            return None
         except dbus.exceptions.DBusException:
             print("Can't connect to DBus")
             return None


### PR DESCRIPTION
Pyqt5 creates an empty dbus package, which will crash the software without further details. See #211 for more