### PR TITLE
Suppress AbstractProfile::CA_CLASH_ADDED for a new CA with the same public key

### DIFF
--- a/core/AbstractProfile.php
+++ b/core/AbstractProfile.php
@@ -156,9 +156,11 @@ abstract class AbstractProfile extends EntityWithDBProperties
         // check if a CA was added
         $x509 = new common\X509();
         $baselineCA = [];
+        $baselineCApublicKey = [];
         foreach ($old->getAttributes("eap:ca_file") as $oldCA) {
             $ca = $x509->processCertificate($oldCA['value']);
             $baselineCA[$ca['sha1']] = $ca['name'];
+            $baselineCApublicKey[$ca['sha1']] = $ca['full_details']['public_key'];
         }
         // remove the new ones that are identical to the baseline
         foreach ($new->getAttributes("eap:ca_file") as $newCA) {
@@ -168,7 +170,12 @@ abstract class AbstractProfile extends EntityWithDBProperties
                 continue;
             }
             // check if a CA with identical DN was added - alert NRO if so
-            if (array_search($ca['name'], $baselineCA) !== FALSE) {
+            $foundSHA1 = array_search($ca['name'], $baselineCA);
+            if ($foundSHA1 !== FALSE) {
+                // but only if the public key does not match
+                if ($baselineCApublicKey[$foundSHA1] === $ca['full_details']['public_key']) {
+                    continue;
+                }
                 $retval[AbstractProfile::CA_CLASH_ADDED] .= "#SHA1 for CA with DN '".$ca['name']."' has SHA1 fingerprints (pre-existing) "./** @scrutinizer ignore-type */ array_search($ca['name'], $baselineCA)." and (added) ".$ca['sha1'];
             } else {
                 $retval[AbstractProfile::CA_ADDED] .= "#CA with DN '"./** @scrutinizer ignore-type */ print_r($ca['name'], TRUE)."' and SHA1 fingerprint ".$ca['sha1']." was added as trust anchor";

--- a/core/common/X509.php
+++ b/core/common/X509.php
@@ -201,6 +201,15 @@ class X509
             return FALSE;
         }
 
+        $pkey = openssl_pkey_get_public($myca);
+        if ($pkey === FALSE) {
+            return FALSE;
+        }
+        $pkeyDetails = openssl_pkey_get_details($pkey);
+        if ($pkeyDetails === FALSE || !isset($pkeyDetails['key'])) {
+            return FALSE;
+        }
+
         $out = [];
         $mydetails = $this->typeOfCertificate($myca, $out);
         if (!isset($mydetails['subject'])) {
@@ -213,6 +222,7 @@ class X509
         $out["sha256"] = openssl_digest($authorityDer, 'SHA256');
         $out["name"] = $mydetails['name'];
         $mydetails['sha1'] = $out['sha1'];
+        $mydetails["public_key"] = $pkeyDetails['key'];
         $out['full_details'] = $mydetails;
         $this->opensslTextParse($myca, $out);
         return $out;


### PR DESCRIPTION
Fix #221

Skip `AbstractProfile::CA_CLASH_ADDED` when the new CA has the same name with an existing CA, but also an identical public key.