### PR TITLE
Fix linux installer for some street addresses

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -556,7 +556,8 @@ class InstallerData(object):
             if Config.use_other_tls_id:
                 return True
             out_str = out.decode('utf-8').strip()
-            subject = re.split(r'\s*[/,]\s*',
+            # split only on commas that are not inside double quotes
+            subject = re.split(r'\s*[/,]\s*(?=([^"]*"[^"]*")*[^"]*$)',
                                re.findall(r'subject=/?(.*)$',
                                           out_str, re.MULTILINE)[0])
             cert_prop = {}


### PR DESCRIPTION
Changed a regex that splits the fields of `subject=` to ignore commas inside double quotes. Added a comment, because the syntax of the forward lookup makes it hard to understand.

This is meant to fix the following error:
```
File "/home/marek/Downloads/eduroam-linux-PdM-polimi-TLS.py", line 547, in __process_p12
    cert_prop[cert_field[0].lower()] = cert_field[1]
IndexError: list index out of range
```

It is caused by the comma after street name, creating a field `32"`. The same certificate works fine with windows installer so I assume that the address is OK and parsing should be improved
```
O = Politecnico di Milano, street = "Piazza Leonardo da Vinci, 32", ST = Milano, 
```