### PR TITLE
add missing argument

### DIFF
--- a/web/user/about_cat.inc.php
+++ b/web/user/about_cat.inc.php
@@ -33,7 +33,7 @@
 $cat = new core\CAT();
 $skinObject = new \web\lib\user\Skinjob("classic");
 /// eduroam CAT, twice the consortium name eduroam, twice eduroam CAT
-$out = sprintf(_("<span class='edu_cat'>%s</span> is built as a cooperation platform."))."<p>".
+$out = sprintf(_("<span class='edu_cat'>%s</span> is built as a cooperation platform."), \config\Master::APPEARANCE['productname'])."<p>".
        sprintf(_("Local %s administrators enter their %s configuration details and based on them, <span class='edu_cat'>%s</span> builds customised installers for a number of popular platforms. ".
                  "An installer prepared for one organisation will not work for users of another one, therefore if your organisation is not on the list, you cannot use this system. ".
                  "Please contact your local administrators and try to influence them to add your %s configuration to <span class='edu_cat'>%s</span>."), 


### PR DESCRIPTION
Opening the "About eduroam CAT" page raises an error message.
Pretty obviously it's because a parameter was forgotten in sprintf() in about_cat.inc.php#36.
https://github.com/GEANT/CAT/blob/b53bc299c7e822c7abd8deb1ee1a9e44f3f465da/web/user/about_cat.inc.php#L36
It seems like this got introduced in https://github.com/GEANT/CAT/commit/60177439c7803c3560405a4e5667fb8f21526fbd.

This PR would fix it.