### PR TITLE
Fix: access array offset on value

### DIFF
--- a/devices/ms/DeviceW8W10.php
+++ b/devices/ms/DeviceW8W10.php
@@ -303,7 +303,7 @@ class DeviceW8W10 extends \devices\ms\WindowsCommon
         $outerId = $this->determineOuterIdString();
         $nea = (\core\common\Entity::getAttributeValue($this->attributes, 'media:wired', 0) === 'on') ? 'true' : 'false';
         $otherTlsName = \core\common\Entity::getAttributeValue($this->attributes, 'eap-specific:tls_use_other_id', 0) === 'on' ? 'true' : 'false';
-        $this->useGeantLink = \core\common\Entity::getAttributeValue($this->attributes, 'device-specific:geantlink', $this->device_id)[0] === 'on' ? true : false;
+        $this->useGeantLink = \core\common\Entity::getAttributeValue($this->attributes, 'device-specific:geantlink', $this->device_id) === 'on' ? true : false;
         $eapConfig = $this->setEapObject();
         $eapConfig->setInnerType($this->selectedEap['INNER']);
         $eapConfig->setInnerTypeDisplay(\core\common\EAP::eapDisplayName($this->selectedEap)['INNER']);


### PR DESCRIPTION
This obviously produces an error at the moment.
`\core\common\Entity::getAttributeValue` returns a value. It won't be an array.

Error message:
`PHP Warning:  Trying to access array offset on value of type null in devices/ms/DeviceW8W10.php on line 306`