### PR TITLE
Remove Ubuntu 16.04 from CI tests

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     needs: [create_test_data_ttls]
     steps:


### PR DESCRIPTION
See [Supported runners and hardware resources](https://docs.github.com/fr/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). This will fix this issue:

![16 04](https://user-images.githubusercontent.com/3234522/206892660-683d0615-983e-4d66-9e75-28ff9fd52598.png)

Note that Ubuntu 18.04 is also being deprecated, fortunately the deprecation schedule has been extended until April 2023:
[GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

Finally, Ubuntu 22.04 will be added by a different merge request: #253.