### PR TITLE
Limit permissions of GitHub workflows

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -3,6 +3,9 @@ name: Test the eduroam linux installer
 # Trigger the workflow on push or pull request
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   python_linting:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Apply least possible privileges to workfkows to limit the damage compromised actions can do to the repository. By specifying any permission explicitly all others are set to none.

* [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)