### PR TITLE
Test Linux installer on newer platforms

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -8,10 +8,10 @@ permissions:
 
 jobs:
   python_linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -52,7 +52,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     needs: [create_test_data_ttls]
     steps:
       - uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-22.04]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     needs: [create_test_data_ttls]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Move linting to `ubuntu-22.04`, with its default Python version 3.10. Unless you prefer `ubuntu-latest`?

Add new versions of Python on Ubuntu 22.04. Should I add them for Ubuntu 18.04 and 20.04 too?