### PR TITLE
Stop testing on Ubuntu 18.04

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         python-version: ["3.6", "3.7", "3.8", "3.9"]
     needs: [create_test_data_ttls]
     steps:


### PR DESCRIPTION
The Ubuntu 18.04 Actions runner is deprecated, and not available any more starting April 2023:
[GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/):
> * update: we extended the deprecation schedule until April 2023 with updated dates for brownouts.

Also update lintign to Python 3.11.