### PR TITLE
Change how JSON is delivered in the user API

### DIFF
--- a/core/UserNetAPI.php
+++ b/core/UserNetAPI.php
@@ -61,6 +61,9 @@ class UserNetAPI extends UserAPI
      */
     public function returnJSON($data, $status = 1, $otherData = [])
     {
+        if (headers_sent()) {
+            throw new \Exception('We were going to send JSON, but there has been sent other data already.');
+        }
         $validator = new \web\lib\common\InputValidation();
         $host = $validator->hostname($_SERVER['SERVER_NAME']);
         if ($host === FALSE) {
@@ -73,7 +76,8 @@ class UserNetAPI extends UserAPI
         if (!empty($otherData)) {
             $returnArray['otherdata'] = $otherData;
         }
-        return(json_encode($returnArray));
+        header('Content-Type: application/json');
+        return(json_encode($returnArray, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR) . "\n");
     }
 
     /**


### PR DESCRIPTION
The User API currently sends JSON payload with an text/html header. This leads to JSON being displayed as if it was HTML, with strange results.

The correct Content-Type according to RFC 4627 is application/json. When sending the appropriate Content-Type, there is no need to further escape the JSON payload.

Finally, add a newline after the JSON data, so it doesn't screw up the terminal when you use curl.