### PR TITLE
Encoding is implicitly UTF-8 in Python 3

### DIFF
--- a/ansible/ManagedSP/templates/daemon/fr_restart.py
+++ b/ansible/ManagedSP/templates/daemon/fr_restart.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 # pylint: disable=invalid-name
 """
 FreeRADIUS restart server

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
  * **************************************************************************
  * Contributions to this work were made on behalf of the GÉANT project,


### PR DESCRIPTION
No need to set it explictly.

https://docs.python.org/3/howto/unicode.html#unicode-literals-in-python-source-code