### PR TITLE
Use single prompt for username and password in Linux installer when using zenity, yad

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -496,10 +496,8 @@ class InstallerData:
                 if shell_command.returncode == 1:
                     self.confirm_exit()
  
-            if self.graphics == 'zenity':
+            if self.graphics == 'zenity' or self.graphics == 'yad':
                 self.username, password, password1 = output.split("\n")
-            elif self.graphics == 'yad':
-                self.username, password, password1, _ = output.split("\n")
  
             if not self.__validate_user_name():
                 continue

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -473,10 +473,10 @@ class InstallerData:
         while True:
             if self.graphics == 'zenity':
                 command = ['zenity', '--forms',
-            		   f"--add-entry={Messages.username_prompt}",
-                       f"--add-password={Messages.enter_password}",
-                       f"--add-password={Messages.repeat_password}",
-                       '--width=500', '--text=' + "aaaa", "--separator", "\n"]
+            		       f"--add-entry={Messages.username_prompt}",
+                           f"--add-password={Messages.enter_password}",
+                           f"--add-password={Messages.repeat_password}",
+                           '--width=500', '--text=' + "aaaa", "--separator", "\n"]
             elif self.graphics == 'yad':
                 command = ['yad', '--form', '--title="Login"',
                            f"--field='{Messages.username_prompt}'",
@@ -525,7 +525,7 @@ class InstallerData:
         if self.silent:
             return
         elif self.graphics == 'zenity' or self.graphics == 'yad':
-        	self.__get_username_password_atomic()
+            self.__get_username_password_atomic()
         else:
             password = "a"
             password1 = "b"

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -212,6 +212,7 @@ class Messages:
     overridden with translated strings.
     """
     quit = "Really quit?"
+    credentials_prompt = "Please, enter your credentials:"
     username_prompt = "enter your userid (username@domain)"
     enter_password = "enter password"
     enter_import_password = "enter your import password"
@@ -470,19 +471,24 @@ class InstallerData:
         """
         use single form to get username, password and password confirmation
         """
+        output_fields_separator = "\n\n\n\n\n"
         while True:
             if self.graphics == 'zenity':
-                command = ['zenity', '--forms',
+                command = ['zenity', '--forms', '--width=500',
+                           "--title=Login",
+                           f"--text={Messages.credentials_prompt}",
                            f"--add-entry={Messages.username_prompt}",
                            f"--add-password={Messages.enter_password}",
                            f"--add-password={Messages.repeat_password}",
-                           '--width=500', '--text=' + "aaaa", "--separator", "\n"]
+                           "--separator", output_fields_separator]
             elif self.graphics == 'yad':
-                command = ['yad', '--form', '--title="Login"',
-                           f"--field='{Messages.username_prompt}'",
-                           f"--field='{Messages.enter_password}:H'",
-                           f"--field='{Messages.repeat_password}:H'",
-                           "--separator", "\n"]
+                command = ['yad', '--form',
+                           "--title=Login",
+                           f"--text={Messages.credentials_prompt}",
+                           f"--field='{Messages.username_prompt}'", self.username,
+                           f"--field='{Messages.enter_password}':H",
+                           f"--field='{Messages.repeat_password}':H",
+                           "--separator", output_fields_separator]
  
             output = ''
             while not output:
@@ -491,13 +497,13 @@ class InstallerData:
                 out, _ = shell_command.communicate()
                 output = out.decode('utf-8')
                 if self.graphics == 'yad':
-                    output = output[:-2]
+                    output = output[:-(len(output_fields_separator)+1)]
                 output = output.strip()
                 if shell_command.returncode == 1:
                     self.confirm_exit()
  
             if self.graphics == 'zenity' or self.graphics == 'yad':
-                self.username, password, password1 = output.split("\n")
+                self.username, password, password1 = output.split(output_fields_separator)
  
             if not self.__validate_user_name():
                 continue

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -212,6 +212,7 @@ class Messages:
     overridden with translated strings.
     """
     quit = "Really quit?"
+    credentials_title = "Credentials"
     credentials_prompt = "Please, enter your credentials:"
     username_prompt = "enter your userid (username@domain)"
     enter_password = "enter password"
@@ -475,7 +476,7 @@ class InstallerData:
         while True:
             if self.graphics == 'zenity':
                 command = ['zenity', '--forms', '--width=500',
-                           "--title=Login",
+                           f"--title={Messages.credentials_title}",
                            f"--text={Messages.credentials_prompt}",
                            f"--add-entry={Messages.username_prompt}",
                            f"--add-password={Messages.enter_password}",
@@ -483,7 +484,7 @@ class InstallerData:
                            "--separator", output_fields_separator]
             elif self.graphics == 'yad':
                 command = ['yad', '--form',
-                           "--title=Login",
+                           f"--title={Messages.credentials_title}",
                            f"--text={Messages.credentials_prompt}",
                            f"--field='{Messages.username_prompt}'", self.username,
                            f"--field='{Messages.enter_password}':H",

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -568,7 +568,7 @@ class InstallerData:
 
     def __get_graphics_support(self) -> None:
         if os.environ.get('DISPLAY') is not None:
-            for cmd in ('zenity', 'kdialog', 'yad'):
+            for cmd in ('yad', 'zenity', 'kdialog'):
                 if self.__check_graphics(cmd):
                     return
         self.graphics = 'tty'

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -476,7 +476,13 @@ class InstallerData:
             		   f"--add-entry={Messages.username_prompt}",
                        f"--add-password={Messages.enter_password}",
                        f"--add-password={Messages.repeat_password}",
-                       '--width=500', '--text=' + "aaaa"]
+                       '--width=500', '--text=' + "aaaa", "--separator", "\n"]
+            elif self.graphics == 'yad':
+                command = ['yad', '--form', '--title="Login"',
+                           f"--field='{Messages.username_prompt}'",
+                           f"--field='{Messages.enter_password}:H'",
+                           f"--field='{Messages.repeat_password}:H'",
+                           "--separator", "\n"]
  
             output = ''
             while not output:
@@ -491,7 +497,9 @@ class InstallerData:
                     self.confirm_exit()
  
             if self.graphics == 'zenity':
-                self.username, password, password1 = output.split("|")
+                self.username, password, password1 = output.split("\n")
+            elif self.graphics == 'yad':
+                self.username, password, password1, _ = output.split("\n")
  
             if not self.__validate_user_name():
                 continue
@@ -518,7 +526,7 @@ class InstallerData:
         """
         if self.silent:
             return
-        elif self.graphics == 'zenity':
+        elif self.graphics == 'zenity' or self.graphics == 'yad':
         	self.__get_username_password_atomic()
         else:
             password = "a"

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -473,7 +473,7 @@ class InstallerData:
         while True:
             if self.graphics == 'zenity':
                 command = ['zenity', '--forms',
-            		       f"--add-entry={Messages.username_prompt}",
+                           f"--add-entry={Messages.username_prompt}",
                            f"--add-password={Messages.enter_password}",
                            f"--add-password={Messages.repeat_password}",
                            '--width=500', '--text=' + "aaaa", "--separator", "\n"]

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -569,7 +569,7 @@ class InstallerData:
 
     def __get_graphics_support(self) -> None:
         if os.environ.get('DISPLAY') is not None:
-            for cmd in ('yad', 'zenity', 'kdialog'):
+            for cmd in ('zenity', 'kdialog', 'yad'):
                 if self.__check_graphics(cmd):
                     return
         self.graphics = 'tty'


### PR DESCRIPTION
It has been bothering me immensely that the CAT uses multiple different dialogs to get username and password, as it is incredibly confusing for the user.

This PR attempts to address it, at least when using zenity, which is the only graphics I have available. It should be straightforward to extend with the correct commands for the other graphics, where available.