### PR TITLE
Prefer `yad` to `zenity` and `kdialog` on Linux

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -518,7 +518,7 @@ class InstallerData:
 
     def __get_graphics_support(self) -> None:
         if os.environ.get('DISPLAY') is not None:
-            for cmd in ('zenity', 'kdialog', 'yad'):
+            for cmd in ('yad', 'zenity', 'kdialog'):
                 if self.__check_graphics(cmd):
                     return
         self.graphics = 'tty'


### PR DESCRIPTION
I believe that `yad` should be prefered to `zenity` and `kdialog`, since it seems to have the most options.
For example, both `yad` and `zenity` support creation of forms with multiple input fields (`kdialog` does not), but only `yad` supports default values for these fields. As far as I can tell, `yad` has been recommended in favour of `zenity` for quite a while now.

This change of priorities won't effect systems where only one of these supported libraries is installed, of course.