### PR TITLE
Fix tkinter and check for load_pkcs12 on Linux

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -99,6 +99,7 @@ except ImportError:
 
 try:
     from OpenSSL import crypto
+    crypto.load_pkcs12 # missing in newer versions
 except (ImportError, AttributeError):  # AttributeError sometimes thrown by old/broken OpenSSL versions
     CRYPTO_AVAILABLE = False
 
@@ -443,9 +444,13 @@ class InstallerData:
                     return output
         elif self.graphics == 'tkinter':
             from tkinter import simpledialog
-            simpledialog.askstring(Config.title, prompt,
-                                   initialvalue=val,
-                                   show="*" if show == 0 else "")
+            while True:
+                output = simpledialog.askstring(Config.title, prompt,
+                                                initialvalue=val,
+                                                show="*" if show == 0 else "")
+                if output:
+                    return output
+                
         else:
             command = []
             if self.graphics == 'zenity':
@@ -755,6 +760,14 @@ class InstallerData:
             shell_command = subprocess.Popen(command, stdout=subprocess.PIPE,
                                              stderr=subprocess.DEVNULL)
             cert, _ = shell_command.communicate()
+        if self.graphics == 'tkinter':
+            from tkinter import filedialog as fd
+            return fd.askopenfilename(title=Messages.p12_title,
+                                      filetypes=(("Certificate file",
+                                                  ("*.p12", "*.P12", "*.pfx",
+                                                   "*.PFX")),))
+
+            
         return cert.decode('utf-8').strip()
 
     @staticmethod


### PR DESCRIPTION
The code for tkinter graphics was missing a return statement as well as the file picker. "load_pkcs12" was removed from pyOpenSSL on version 23.3.0, so a check for its availability has been added.