### PR TITLE
Update Ubuntu runners

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   python_linting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -51,8 +51,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-20.04]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        os: [ubuntu-22.04]
+        python-version: ["3.7", "3.8", "3.9"]
     needs: [create_test_data_ttls]
     steps:
       - uses: actions/checkout@v4
@@ -74,13 +74,13 @@ jobs:
           echo "run_installer()" >> devices/linux/Files/main.py
           cd devices/linux/Files/
           python main.py -d -s --username eduroam_user --password eduroam_password
-  test_ubuntu_22:
+  test_ubuntu_24:
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-22.04]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-24.04]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     needs: [create_test_data_ttls]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Bump Ubuntu 22.04 to 24.04.
- Bump Ubuntu 20.04 to 22.04 because the 20.04 runner image has been retired:
  [Ubuntu 20 image is closing down](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down)

Fixes #322.

Unfortunately, this means Python 3.6 cannot be tested any more, from the CI error on Ubuntu 22.04 runners:
```
  Version 3.6 was not found in the local cache
  Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```