### PR TITLE
iwd: separate server domain masks with semicolons

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -1000,7 +1000,7 @@ class IwdConfiguration:
             else:
                 domainMask.append(server)
 
-        return join_with_separator(domainMask, ':')
+        return join_with_separator(domainMask, ';')
 
     def generate_iwd_config(self, ssid: str, user_data: Type[InstallerData]) -> None:
         """Generate an appropriate IWD 8021x config for a given EAP method"""


### PR DESCRIPTION
As specified in iwd.network(5) under Network Authentication Settings, multiple server domain masks should be separated by semicolons, not colons.

```
            ├───────────────────────────────┼────────────────────────────┤
            │EAP-TLS-ServerDomainMask,      │ string A mask for the      │
            │EAP-TTLS-ServerDomainMask,     │ domain names contained in  │
            │EAP-PEAP-ServerDomainMask      │ the server's certificate.  │
            │                               │ At least one of the domain │
            │                               │ names present in the       │
            │                               │ certificate's Subject      │
            │                               │ Alternative Name           │
            │                               │ extension's DNS Name       │
            │                               │ fields or the Common Name  │
            │                               │ has to match at least one  │
            │                               │ mask, or authentication    │
            │                               │ will fail.  Multiple masks │
            │                               │ can be given separated by  │
            │                               │ semicolons.  The masks are │
            │                               │ split into segments at the │
            │                               │ dots.  Each segment has to │
            │                               │ match its corresponding    │
            │                               │ label in the domain name.  │
            │                               │ An asterisk segment in the │
            │                               │ mask matches any label.    │
            │                               │ An asterisk segment at the │
            │                               │ beginning of the mask      │
            │                               │ matches one or more        │
            │                               │ consecutive labels from    │
            │                               │ the beginning of the       │
            │                               │ domain string.             │
            ├───────────────────────────────┼────────────────────────────┤
```