### PR TITLE
avoid relying on legacy undocumented behavior

### DIFF
--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -946,11 +946,13 @@ class WpaConf:
         """
 
         if Config.eap_outer in ('PEAP', 'TTLS'):
-            interface += f"phase2=\"auth={Config.eap_inner}\"\n" \
-                         f"\tpassword=\"{user_data.password}\"\n"
             if Config.anonymous_identity != '':
-                interface += f"\tanonymous_identity=\"{Config.anonymous_identity}\"\n"
-
+                outer_identity = Config.anonymous_identity
+            else:
+                outer_identity = user_data.username
+            interface += f"phase2=\"auth={Config.eap_inner}\"\n" \
+                         f"\tpassword=\"{user_data.password}\"\n" \
+                         f"\tanonymous_identity=\"{outer_identity}\"\n"
         elif Config.eap_outer == 'TLS':
             interface += "\tprivate_key_passwd=\"{}\"\n" \
                          "\tprivate_key=\"{}/.cat_installer/user.p12" \
@@ -1207,6 +1209,10 @@ class CatNMConfigTool:
         else:
             match_key = 'subject-match'
             match_value = server_name
+        if Config.anonymous_identity != '':
+            outer_identity = Config.anonymous_identity
+        else:
+            outer_identity = self.user_data.username
         s_8021x_data = {
             'eap': [Config.eap_outer.lower()],
             'identity': self.user_data.username,
@@ -1216,8 +1222,7 @@ class CatNMConfigTool:
         if Config.eap_outer in ('PEAP', 'TTLS'):
             s_8021x_data['password'] = self.user_data.password
             s_8021x_data['phase2-auth'] = Config.eap_inner.lower()
-            if Config.anonymous_identity != '':
-                s_8021x_data['anonymous-identity'] = Config.anonymous_identity
+            s_8021x_data['anonymous-identity'] = outer_identity
             s_8021x_data['password-flags'] = 1
         elif Config.eap_outer == 'TLS':
             s_8021x_data['client-cert'] = dbus.ByteArray(


### PR DESCRIPTION
Leaving the `anonymous_identity` field blank causes it to default to the username, but this is undocumented legacy behavior. NetworkManager [retained that behavior with a warning](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/5580b982ac916ac0f878bcd606801ce7c82aee68/src/core/devices/wifi/nm-wifi-utils.c#L1337-1343). It would be nice to be explicit: if CAT wants the username to be used as the outer identity, say so, just like we're already doing for iwd:

https://github.com/GEANT/CAT/blob/c47ac74b7f5e6f4a288b2e959666c5c65081b8cc/devices/linux/Files/main.py#L1037-L1044