### PR TITLE
Disable automatic typo fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,4 @@ repos:
     rev: v1.46.2
     hooks:
       - id: typos
+        args: ["--force-exclude"]

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,8 +9,8 @@ checks:
         no_long_variable_names:
             maximum: '20'
         more_specific_types_in_doc_comments: true
-        return_doc_comment_if_not_inferable: true
-        param_doc_comment_if_not_inferable: true
+        return_doc_comment_if_not_inferrable: true
+        param_doc_comment_if_not_inferrable: true
         parameter_doc_comments: true
         no_goto: true
         properties_in_camelcaps: true

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,8 @@ extend-exclude = [
 
 [default.extend-identifiers]
 recognisedOShs20 = "recognisedOShs20"
+return_doc_comment_if_not_inferrable = "return_doc_comment_if_not_inferrable"
+param_doc_comment_if_not_inferrable = "param_doc_comment_if_not_inferrable"
 SELECTs = "SELECTs"
 setRADIUSconfig = "setRADIUSconfig"
 StrCpy = "StrCpy"


### PR DESCRIPTION
It's error prone and may introduce bugs.
    
Partially revert 3bd1e3c3, this can only be addressed upstream in [Scrutinizer](https://scrutinizer-ci.com/). Besides, `inferrable` is uncommon but correct [according to the OED](https://www.oed.com/search/dictionary/?q=inferrable).

Rename `_typos.toml` → `.typos.toml` for consistency with `.ruff.toml`.

Finally, pass `--force-exclude` to typos, so that pre-commit/prek cannot override excluded files.
