### PR TITLE
fix broken Yes/No buttons in linux python installer

### DIFF
--- a/devices/linux/Files/eduroam_linux_main.sh
+++ b/devices/linux/Files/eduroam_linux_main.sh
@@ -132,7 +132,7 @@ function ask {
   fi
   if [ ! -z "$YAD" ] ; then
      text=$(echo "${1}" | fmt -w60)
-     if "$YAD" --image="dialog-question" --button=gtk-yes:0 --button=gtk-no:1 --width=500 --wrap --text="${text}\n\n${2}" --title="$TITLE" 2>/dev/null ; then
+     if "$YAD" --image="dialog-question" --button=yad-yes:0 --button=yad-no:1 --width=500 --wrap --text="${text}\n\n${2}" --title="$TITLE" 2>/dev/null ; then
        return 0
      else
        return 1

--- a/devices/linux/Files/main.py
+++ b/devices/linux/Files/main.py
@@ -441,8 +441,8 @@ class InstallerData:
                            '--title=' + Config.title]
             elif self.graphics == 'yad':
                 command = ['yad', '--image="dialog-question"',
-                           '--button=gtk-yes:0',
-                           '--button=gtk-no:1',
+                           '--button=yad-yes:0',
+                           '--button=yad-no:1',
                            '--width=500',
                            '--wrap',
                            '--text=' + question + "\n\n" + prompt,


### PR DESCRIPTION
This fixes broken yes/no buttons:
<img width="592" height="183" alt="image" src="https://github.com/user-attachments/assets/21fd9d10-1033-42db-aa24-efad51efb0ec" />
